### PR TITLE
arm64: Import heap memory pages from SimPoint slice

### DIFF
--- a/arch/arm64/common/head.S
+++ b/arch/arm64/common/head.S
@@ -5,6 +5,7 @@
 #include <asm/assembler.h>
 #include <asm/asm-offsets.h>
 #include <asm/sysreg.h>
+#include <asm/page_utils.h>
 #include <target/paging.h>
 
 #define ARM_ROM_OFFSET	0x850
@@ -275,65 +276,6 @@ ENTRY(__linux_boot_el2)
 ENDPROC(__linux_boot_el2)
 #endif
 
-# Macro to create a table entry to the next page.
-#	tbl:	page table address
-#	virt:	virtual address
-#	shift:	#imm page table shift
-#	ptrs:	#imm pointers per table page
-# Preserves:	virt
-# Corrupts:	tmp1, tmp2
-# Returns:	tbl -> next level table page address
-	.macro	create_table_entry, tbl, virt, shift, ptrs, tmp1, tmp2
-	lsr	\tmp1, \virt, #\shift
-	and	\tmp1, \tmp1, #\ptrs - 1	// table index
-	add	\tmp2, \tbl, #PAGE_SIZE
-	orr	\tmp2, \tmp2, #PMD_TYPE_TABLE	// address of next table and entry type
-	str	\tmp2, [\tbl, \tmp1, lsl #3]
-	add	\tbl, \tbl, #PAGE_SIZE		// next level table page
-	.endm
-
-# Macro to populate the PGD (and possibily PUD) for the corresponding
-# block entry in the next level (tbl) for the given virtual address.
-# Preserves:	tbl, next, virt
-# Corrupts:	tmp1, tmp2
-	.macro	create_pgd_entry, tbl, virt, tmp1, tmp2
-	create_table_entry \tbl, \virt, PGDIR_SHIFT, PTRS_PER_PGD, \tmp1, \tmp2
-#if BPGT_PGTABLE_LEVELS > 3
-	create_table_entry \tbl, \virt, PUD_SHIFT, PTRS_PER_PUD, \tmp1, \tmp2
-#endif
-#if BPGT_PGTABLE_LEVELS > 2
-	create_table_entry \tbl, \virt, BPGT_TABLE_SHIFT, PTRS_PER_PTE, \tmp1, \tmp2
-#endif
-	.endm
-
-	.macro	locate_pgd_entry, tbl
-	add	\tbl, \tbl, #PAGE_SIZE		// next level table page
-#if BPGT_PGTABLE_LEVELS > 3
-	add	\tbl, \tbl, #PAGE_SIZE		// next level table page
-#endif
-#if BPGT_PGTABLE_LEVELS > 2
-	add	\tbl, \tbl, #PAGE_SIZE		// next level table page
-#endif
-	.endm
-
-# Macro to populate block entries in the page table for the start..end
-# virtual range (inclusive).
-# Preserves:	tbl, flags
-# Corrupts:	phys, start, end, pstate
-	.macro	create_block_map, tbl, flags, phys, start, end
-	lsr	\phys, \phys, #BPGT_BLOCK_SHIFT
-	lsr	\start, \start, #BPGT_BLOCK_SHIFT
-	and	\start, \start, #PTRS_PER_PTE - 1		// table index
-	orr	\phys, \flags, \phys, lsl #BPGT_BLOCK_SHIFT	// table entry
-	lsr	\end, \end, #BPGT_BLOCK_SHIFT
-	and	\end, \end, #PTRS_PER_PTE - 1			// table end index
-9999:	str	\phys, [\tbl, \start, lsl #3]			// store the entry
-	add	\start, \start, #1				// next entry
-	add	\phys, \phys, #BPGT_BLOCK_SIZE			// next block
-	cmp	\start, \end
-	b.ls	9999b
-	.endm
-
 # Setup the initial page tables. We only setup the barest amount which is
 # required to get the kernel running. The following sections are required:
 #   - identity mapping to enable the MMU (low address, TTBR0)
@@ -418,6 +360,17 @@ ENTRY(__create_page_tables)
 	add	x6, x6, #PERCPU_STACKS_SIZE
 	mov	x3, x24				// PHYS_OFFSET
 	create_block_map x0, x7, x3, x5, x6
+
+#ifdef CONFIG_GEM5
+	# Map memory pages of heap in SimPoint slice.
+	# - Function simpoint_heap_map_entry is defined in the slice source code.
+	# - Label simpoint_heap_map_exit is target of the branching at the end of
+	#   fucntion simpoint_heap_map_entry.
+.global simpoint_heap_map_exit
+	b simpoint_heap_map_entry
+simpoint_heap_map_exit:
+#endif
+
 
 #if defined(CONFIG_MMU_IDMAP_DEVICE) && defined(IDMAP_DEV_BASE)
 	# Map identity device area for early console

--- a/arch/arm64/common/sdfirm.lds.S
+++ b/arch/arm64/common/sdfirm.lds.S
@@ -77,6 +77,7 @@ SECTIONS
 		__init_data_end = .;
 #endif
 		DATA_DATA
+		GEM5_HEAP
 	}
 	__edata = .;				/* end of data sections */
 

--- a/arch/arm64/include/asm/page_utils.h
+++ b/arch/arm64/include/asm/page_utils.h
@@ -1,0 +1,81 @@
+#ifndef __PAGE_UTILS_ARM64_H_INCLUDE__
+#define __PAGE_UTILS_ARM64_H_INCLUDE__
+
+#if defined(__ASSEMBLY__)
+
+#include <target/config.h>
+#include <target/compiler.h>
+#include <target/init.h>
+#include <target/arch.h>
+#include <target/paging.h>
+#include <asm/asm-offsets.h>
+#include <asm/sysreg.h>
+
+
+/*
+ * Macro to create a table entry to the next page.
+ *	tbl:	page table address
+ *	virt:	virtual address
+ *	shift:	#imm page table shift
+ *	ptrs:	#imm pointers per table page
+ * Preserves:	virt
+ * Corrupts:	tmp1, tmp2
+ * Returns:	tbl -> next level table page address
+ */
+	.macro	create_table_entry, tbl, virt, shift, ptrs, tmp1, tmp2
+	lsr	\tmp1, \virt, #\shift
+	and	\tmp1, \tmp1, #\ptrs - 1	// table index
+	add	\tmp2, \tbl, #PAGE_SIZE
+	orr	\tmp2, \tmp2, #PMD_TYPE_TABLE	// address of next table and entry type
+	str	\tmp2, [\tbl, \tmp1, lsl #3]
+	add	\tbl, \tbl, #PAGE_SIZE		// next level table page
+	.endm
+
+/*
+ * Macro to populate the PGD (and possibily PUD) for the corresponding
+ * block entry in the next level (tbl) for the given virtual address.
+ * Preserves:	tbl, next, virt
+ * Corrupts:	tmp1, tmp2
+ */
+	.macro	create_pgd_entry, tbl, virt, tmp1, tmp2
+	create_table_entry \tbl, \virt, PGDIR_SHIFT, PTRS_PER_PGD, \tmp1, \tmp2
+#if BPGT_PGTABLE_LEVELS > 3
+	create_table_entry \tbl, \virt, PUD_SHIFT, PTRS_PER_PUD, \tmp1, \tmp2
+#endif
+#if BPGT_PGTABLE_LEVELS > 2
+	create_table_entry \tbl, \virt, BPGT_TABLE_SHIFT, PTRS_PER_PTE, \tmp1, \tmp2
+#endif
+	.endm
+
+	.macro	locate_pgd_entry, tbl
+	add	\tbl, \tbl, #PAGE_SIZE		// next level table page
+#if BPGT_PGTABLE_LEVELS > 3
+	add	\tbl, \tbl, #PAGE_SIZE		// next level table page
+#endif
+#if BPGT_PGTABLE_LEVELS > 2
+	add	\tbl, \tbl, #PAGE_SIZE		// next level table page
+#endif
+	.endm
+
+/*
+ * Macro to populate block entries in the page table for the start..end
+ * virtual range (inclusive).
+ * Preserves:	tbl, flags
+ * Corrupts:	phys, start, end, pstate
+ */
+	.macro	create_block_map, tbl, flags, phys, start, end
+	lsr	\phys, \phys, #BPGT_BLOCK_SHIFT
+	lsr	\start, \start, #BPGT_BLOCK_SHIFT
+	and	\start, \start, #PTRS_PER_PTE - 1		// table index
+	orr	\phys, \flags, \phys, lsl #BPGT_BLOCK_SHIFT	// table entry
+	lsr	\end, \end, #BPGT_BLOCK_SHIFT
+	and	\end, \end, #PTRS_PER_PTE - 1			// table end index
+9999:	str	\phys, [\tbl, \start, lsl #3]			// store the entry
+	add	\start, \start, #1				// next entry
+	add	\phys, \phys, #BPGT_BLOCK_SIZE			// next block
+	cmp	\start, \end
+	b.ls	9999b
+	.endm
+#endif
+
+#endif /* __PAGE_UTILS_ARM64_H_INCLUDE__ */

--- a/include/asm-generic/sdfirm.lds.h
+++ b/include/asm-generic/sdfirm.lds.h
@@ -88,3 +88,13 @@
 	BSS(bss_align)						\
 	. = ALIGN(stop_align);					\
 	__bss_stop = .;
+
+#ifdef CONFIG_GEM5
+	#define GEM5_HEAP			\
+	. = ALIGN(PAGE_SIZE);		\
+	simpoint_heap_start = .;	\
+	*(.SIMPOINT_MEM_PAGES)		\
+	simpoint_heap_end = .;
+#else
+	#define GEM5_HEAP
+#endif


### PR DESCRIPTION
- Link page data of heap memory in section ".SIMPOINT_MEM_PAGES" of SimPoint
  slice into the ".data" section of sdfirm.
- In "__create_page_tables", page table entries are created for these pages by
  calling the function "simpoint_heap_map_entry" provided in SimPoint slice.
  Additionaly, label "simpoint_heap_map_exit" is inserted and is used as the
  branching target at the end of "simpoint_heap_map_entry". A normal return,
  i.e. a ret instruction is NOT used here, because we want to reserve all
  registers except those used in creating page table entry.
- Macros for creating page entry are moved from head.S to asm/page_utils.h.

Signed-off-by: Ian Jiang <ianjiang.ict@gmail.com>