### PR TITLE
bench: Refine tlbtest

### DIFF
--- a/tests/bench/Kconfig
+++ b/tests/bench/Kconfig
@@ -97,6 +97,18 @@ endif
 config TLB_TEST
 	bool "Test TLB flush"
 
+if TLB_TEST
+
+config TLB_TEST_FLUSH_RANGE
+	bool "Test flush range"
+	default y
+
+config TLB_TEST_FLUSH_ALL
+	bool "Test flush all"
+	default n
+
+endif
+
 source tests/bench/coremark/Kconfig
 source tests/bench/c_fft/Kconfig
 source tests/bench/jpgenc/Kconfig

--- a/tests/bench/tlbtest.c
+++ b/tests/bench/tlbtest.c
@@ -1,7 +1,3 @@
-/*
- * C program for Tower of Hanoi using Recursion
- */
-
 #include <target/bench.h>
 #include <target/tlbtest.h>
 #include <target/cpus.h>
@@ -14,7 +10,7 @@ struct tlbtest_percpu {
 } __cache_aligned;
 static struct tlbtest_percpu tlbtest_ctx[MAX_CPU_NUM];
 
-#define BUF_SIZE 1024
+#define BUF_SIZE 128
 
 #ifdef HOSTED
 void main (int argc, char *argv[])
@@ -28,17 +24,25 @@ int tlbtest(caddr_t percpu_area)
 
 	tlbtest_ctx[smp_processor_id()].ptr =
 		(struct tlbtest_context *)percpu_area;
+	printf("Start tlbtest\n");
 
+#ifdef CONFIG_TLB_TEST_FLUSH_RANGE
 	for (i = 0; i < BUF_SIZE; i+= 17)
 		test_buf_1[i] = i;
+	printf("Start tlbtest flush range\n");
 	flush_tlb_range_kern((caddr_t)test_buf_1,
 		(caddr_t)(test_buf_1+BUF_SIZE));
+#endif
 
+#ifdef CONFIG_TLB_TEST_FLUSH_ALL
 	for (i = 0; i < BUF_SIZE; i+= 13)
 		test_buf_2[i] = i;
+	printf("Start tlbtest flush all\n");
 	flush_tlb_all();
+#endif
 
 	tlbtest_ctx[smp_processor_id()].ptr->result = 1;
+	printf("End of tlbtest. Success\n");
 	return 1;
 }
 __define_testfn(tlbtest, sizeof(struct tlbtest_context), SMP_CACHE_BYTES,


### PR DESCRIPTION
- Add printing at start and end of test.
- Reduce data buffer size to speed up test.
- Make flush range and flush all optional

Signed-off-by: Ian Jiang <ianjiang.ict@gmail.com>