### PR TITLE
Fix timer test shutdown and add shutdown for Spike

### DIFF
--- a/arch/riscv/common/head.S
+++ b/arch/riscv/common/head.S
@@ -302,6 +302,11 @@ ENDPROC(get_tp)
 ENTRY(sim_shutdown)
 	j	test_section_end
 ENTRY(test_section_end)
+#ifdef CONFIG_SPIKE_SHUTDOWN_SPIKE
+	li a0, CONFIG_SPIKE_CSR_MIMPID
+	csrr a1, CSR_MIMPID
+	beq a0, a1, htif_poweroff
+#endif
 #ifdef CONFIG_SPIKE_SHUTDOWN_DUOWEN
 	csrw	satp, zero
 	li	a0, 0xFFFFFFFF00

--- a/arch/riscv/mach-spike/Kconfig
+++ b/arch/riscv/mach-spike/Kconfig
@@ -150,6 +150,20 @@ endmenu
 
 menu "Shutdown scheme"
 
+config SPIKE_SHUTDOWN_SPIKE
+	bool "Spike HTIF poweroff"
+	help
+	  Write to HTIF at specific CSR mimpid.
+	select SBI_CSR_MIMPID if SBI
+
+if SPIKE_SHUTDOWN_SPIKE
+
+config SPIKE_CSR_MIMPID
+	hex "CSR mimpid value identified to Spike"
+	default 0x7370696B
+
+endif
+
 config SPIKE_SHUTDOWN_DUOWEN
 	bool "Duowen IO write"
 	help

--- a/arch/riscv/mach-spike/mach.c
+++ b/arch/riscv/mach-spike/mach.c
@@ -44,9 +44,7 @@
 #ifdef CONFIG_SHUTDOWN
 void board_shutdown(void)
 {
-#ifndef CONFIG_SMP
 	sim_shutdown();
-#endif
 }
 #endif
 

--- a/arch/riscv/sbi/Kconfig
+++ b/arch/riscv/sbi/Kconfig
@@ -21,6 +21,10 @@ if SBI
 config SBI_PAYLOAD
 	bool "Enable SBI payload binary"
 
+config SBI_CSR_MIMPID
+	bool "Support reading the mimpid CSR"
+	default n
+
 if SBI_PAYLOAD
 
 config SBI_PAYLOAD_PATH

--- a/arch/riscv/sbi/sbi_emulate_csr.c
+++ b/arch/riscv/sbi/sbi_emulate_csr.c
@@ -90,6 +90,11 @@ int sbi_emulate_csr_read(int csr_num, u32 hartid, ulong mstatus,
 	case CSR_MHARTID:
 		*csr_val = hartid;
 		break;
+#ifdef CONFIG_SBI_CSR_MIMPID
+	case CSR_MIMPID:
+		*csr_val = csr_read(CSR_MIMPID);
+		break;
+#endif
 	default:
 		sbi_printf("%s: hartid%d: invalid csr_num=0x%x\n", __func__,
 			   hartid, csr_num);


### PR DESCRIPTION
- Use sim_shutdown() instead of board_shutdown(), as the later depends
on not defining of SMP.
- Support reading CSR mimpid in sbi.
- Add shutdown for Spike at specified CSR mimpid.
