### PR TITLE
bench: Add pass and fail sub-functions for tlbtest and md5

### DIFF
--- a/tests/bench/hanoitower.c
+++ b/tests/bench/hanoitower.c
@@ -50,6 +50,9 @@ static void hanoitower_run(int num, char frompeg, char topeg, char auxpeg)
 #define CONFIG_HANOITOWER_DEPTH 4
 #endif
 
+static int hanoitower_t_pass(void) { return 1; }
+static int hanoitower_t_fail(void) { return 0; }
+
 #ifdef HOSTED
 void main (int argc, char *argv[])
 #else
@@ -74,11 +77,11 @@ int hanoitower(caddr_t percpu_area)
 	if (hanoitower_results[num-1] == 
 			hanoitower_ctx[smp_processor_id()].ptr->move_cnt) {
 		printf("Bench %s(disk_num = %d): Success.\n", __func__, num);
-		return 1;
+		return hanoitower_t_pass();
 	} else {
 		printf("Bench %s(disk_num = %d): Failed. move_cnt = %d\n", __func__,
 				num, hanoitower_ctx[smp_processor_id()].ptr->move_cnt);
-		return 0;
+		return hanoitower_t_fail();
 	}
 }
 __define_testfn(hanoitower, sizeof(struct hanoitower_context), SMP_CACHE_BYTES,

--- a/tests/bench/md5.c
+++ b/tests/bench/md5.c
@@ -168,6 +168,9 @@ void md5_run(const uint8_t *initial_msg, size_t initial_len, uint8_t *digest) {
     to_bytes(h3, digest + 12);
 }
  
+static int md5_t_pass(void) { return 1; }
+static int md5_t_fail(void) { return 0; }
+
 #ifdef HOSTED
 int main(int argc, char **argv) {
 #else
@@ -216,10 +219,10 @@ int md5(caddr_t percpu_area)
  
 	if (error_cnt == 0) {
 		printf("MD5 test Success\n");
-    	return 1;
+		return md5_t_pass();
 	} else {
 		printf("MD5 test Failed\n");
-		return 0;
+		return md5_t_fail();
 	}
 }
 


### PR DESCRIPTION
This is useful when we want to check running result automatically.
First get PCs of the pass and fail sub-functions, then check out if they exist in the instruction trace.
