### PR TITLE
Fix align of struct scratch for RISCV32

### DIFF
--- a/arch/riscv/include/asm/cpus.h
+++ b/arch/riscv/include/asm/cpus.h
@@ -62,9 +62,10 @@
 #define wake_cpu()
 
 #ifndef __ASSEMBLY__
+#include<asm/assembler.h>
 struct scratch {
 	unsigned long sp;
-};
+} __attribute__((aligned(STACK_ALIGN)));
 #endif
 
 #include <asm/mach/cpus.h>


### PR DESCRIPTION
The struct scratch must be aligned to STACK_ALIGN (16 bytes).
Otherwise it causes the mis-align of SP and introduces a bug in
printf for %llx format under RISCV32.

Signed-off-by: Ian Jiang <ianjiang.ict@gmail.com>