### PR TITLE
i2c: Add IRQ test in reading VIP

### DIFF
--- a/drivers/i2c/Kconfig
+++ b/drivers/i2c/Kconfig
@@ -30,6 +30,10 @@ config DW_I2C_TX_TL
 	default 0
 	range 0 255
 
+config DW_I2C_TEST_IRQ
+	bool "Test IRQ handler for DW I2C"
+	default n
+
 endif
 
 endmenu


### PR DESCRIPTION
- Install a IRQ handler for certain I2C Master.
- Expects IRQ and check interrupts status in reading of VIP.

Signed-off-by: Ian Jiang <ianjiang.ict@gmail.com>