### PR TITLE
bench: Run and get performance for many times in CoreMark

### DIFF
--- a/tests/bench/coremark/Kconfig
+++ b/tests/bench/coremark/Kconfig
@@ -7,12 +7,20 @@ menuconfig COREMARK
 
 if COREMARK
 
+config COREMARK_FORCE_VERY_QUICK
+	bool "Use minimal data size and iteration count to run quickly"
+
+config COREMARK_RUN_CNT
+	int "How many times to run those iterations"
+	default 3
+
+config COREMARK_SIMPLE_REPORT
+	bool "Give report of simple format"
+	default y
+
 config COREMARK_ITERATION_CNT
 	int "CoreMark iterations count"
+	depends !COREMARK_FORCE_VERY_QUICK
 	default 200
-
-config COREMARK_DATA_SIZE
-	int "CoreMark data size per CPU"
-	default 2000
 
 endif

--- a/tests/bench/coremark/coremark_common.h
+++ b/tests/bench/coremark/coremark_common.h
@@ -23,10 +23,22 @@ Original Author: Shay Gal-on
 /* Configuration: TOTAL_DATA_SIZE
         Define total size for data algorithms will operate on
 */
-#ifndef CONFIG_COREMARE_DATA_SIZE
+
+#ifdef CONFIG_COREMARK_FORCE_VERY_QUICK
+#define TOTAL_DATA_SIZE 400
+#define ITERATION_CNT 1
+#else
+#define ITERATION_CNT CONFIG_COREMARK_ITERATION_CNT
+#endif
+
+#ifdef CONFIG_COREMARK_RUN_CNT
+#define RUN_CNT CONFIG_COREMARK_RUN_CNT
+#else
+#define RUN_CNT 1
+#endif
+
 #ifndef TOTAL_DATA_SIZE
 #define TOTAL_DATA_SIZE 2 * 1000
-#endif
 #endif
 
 #define SEED_ARG      0
@@ -67,6 +79,7 @@ typedef ee_u32 secs_ret;
 #define MAIN_RETURN_TYPE int
 #endif
 
+CORE_TICKS get_time_ticks(void);
 void       start_time(void);
 void       stop_time(void);
 CORE_TICKS get_time(void);

--- a/tests/bench/coremark/coremark_portme.c
+++ b/tests/bench/coremark/coremark_portme.c
@@ -126,6 +126,18 @@ volatile ee_s32 seed5_volatile = 0;
 #define EE_TICKS_PER_SEC (NSECS_PER_SEC / TIMER_RES_DIVIDER)
 
 #if SAMPLE_TIME_IMPLEMENTATION
+#ifdef CONFIG_COREMARK_SIMPLE_REPORT
+void start_time(void) { return; }
+void stop_time(void) { return; }
+CORE_TICKS get_time(void) { return 0; }
+CORE_TICKS
+get_time_ticks(void)
+{
+    CORETIMETYPE curr_ticks;
+    GETMYTIME(&curr_ticks);
+    return (CORE_TICKS)curr_ticks;
+}
+#else
 /** Define Host specific (POSIX), or target specific global time variables. */
 static CORETIMETYPE start_time_val, stop_time_val;
 
@@ -181,9 +193,10 @@ get_time(void)
 {
     CORE_TICKS elapsed
         = (CORE_TICKS)(MYTIMEDIFF(stop_time_val, start_time_val));
-	printf("Time: start = 0x%llx, stop = 0x%llx, elapsed = 0x%llx\n", start_time_val, stop_time_val, elapsed);
     return elapsed;
 }
+CORE_TICKS get_time_ticks(void) { return 0; }
+#endif
 /* Function: time_in_secs
         Convert the value returned by get_time to seconds.
 

--- a/tests/bench/coremark/coremark_portme.h
+++ b/tests/bench/coremark/coremark_portme.h
@@ -79,6 +79,8 @@ typedef size_t CORE_TICKS;
 #elif HAS_TIME_H
 #include <time.h>
 typedef clock_t CORE_TICKS;
+#define iterations_per_sec(iterations, ticks) \
+         ((unsigned long long)iterations * 1000000 / ticks)
 #else
 #error \
     "Please define type of CORE_TICKS and implement start_time, end_time get_time and time_in_secs functions!"


### PR DESCRIPTION
- CONFIG_COREMARK_RUN_CNT: How many times to run certain count
  (defined with CONFIG_COREMARK_ITERATION_CNT) of interations.
- CONFIG_COREMARK_SIMPLE_REPORT: Give a simple report rather than
  the original one with details.
- CONFIG_COREMARK_FORCE_VERY_QUICK: Use minimal data size and
  iteration count to run quickly.

Signed-off-by: Ian Jiang <ianjiang.ict@gmail.com>