### PR TITLE
scripts: Add a file converting tool to swap bytes in group of certain…

### DIFF
--- a/arch/riscv/include/asm/page.h
+++ b/arch/riscv/include/asm/page.h
@@ -43,6 +43,7 @@
 #define __PAGE_RISCV_H_INCLUDE__
 
 #include <target/barrier.h>
+#include <target/tlb.h>
 
 /* This file is intended to be used by page allocator and paging. Page
  * allocator requires basic address space range definitions. And paging
@@ -186,14 +187,15 @@ extern unsigned long empty_zero_page[PAGE_SIZE / sizeof (unsigned long)];
 static inline void set_pte(pteval_t *ptep, pteval_t pte)
 {
 	mmu_dbg_tbl("PTE: %016llx: %016llx\n", ptep, pte);
-	*ptep = pte;
+	WRITE_ONCE(ptep, pte);
+	mmu_barrier();
 }
 /* #define set_pte(ptep, pte)	((*(ptep) = (pte)), page_wmb()) */
 #define ARCH_HAVE_SET_PMD 1
 static inline void set_pmd(pmdval_t *pmdp, pmdval_t pmd)
 {
 	mmu_dbg_tbl("PMD: %016llx: %016llx\n", pmdp, pmd);
-	*pmdp = pmd;
+	WRITE_ONCE(pmdp, pmd);
 }
 /* #define set_pmd(pmdp, pmd)	((*(pmdp) = (pmd)), page_wmb()) */
 #if PGTABLE_LEVELS > 2
@@ -201,7 +203,7 @@ static inline void set_pmd(pmdval_t *pmdp, pmdval_t pmd)
 static inline void set_pud(pudval_t *pudp, pudval_t pud)
 {
 	mmu_dbg_tbl("PUD: %016llx: %016llx\n", pudp, pud);
-	*pudp = pud;
+	WRITE_ONCE(pudp, pud);
 }
 /* #define set_pud(pudp, pud)	((*(pudp) = (pud)), page_wmb()) */
 #endif /* PGTABLE_LEVELS > 2 */
@@ -210,7 +212,7 @@ static inline void set_pud(pudval_t *pudp, pudval_t pud)
 static inline void set_pgd(pgdval_t *pgdp, pgdval_t pgd)
 {
 	mmu_dbg_tbl("PGD: %016llx: %016llx\n", pgdp, pgd);
-	*pgdp = pgd;
+	WRITE_ONCE(pgdp, pgd);
 }
 /* #define set_pgd(pgdp, pgd)	((*(pgdp) = (pgd)), page_wmb()) */
 #endif /* PGTABLE_LEVELS > 3 */

--- a/scripts/swap-bytes.py
+++ b/scripts/swap-bytes.py
@@ -1,0 +1,58 @@
+#!/usr/bin/python3
+
+import sys
+
+group_size = 4
+
+if (len(sys.argv) < 2):
+	print("Usage:")
+	print("\t" + sys.argv[0] + " input-file [group-size]")
+	print("\tgroup-size: default = " + str(group_size))
+	sys.exit(1)
+if (len(sys.argv) >= 3):
+	group_size = int(sys.argv[2])
+	if (group_size < 0 or group_size > 128):
+		print("Invalid group_size = " + sys.argv[2])
+		sys.exit(1)
+
+input_filename = sys.argv[1]
+output_filename = input_filename + "-swap" + str(group_size) + "bytes"
+
+try:
+	input_fd = open(input_filename, "rb")
+except IOError:
+	printf("Error: Failed to open input file " + input_filename)
+	sys.exit(1)
+try:
+	output_fd = open(output_filename, "wb")
+except IOError:
+	printf("Error: Failed to open output file " + output_filename)
+	sys.exit(1)
+
+byte_list = list(input_fd.read())
+input_fd.close()
+
+input_byte_cnt = len(byte_list)
+group_cnt = int((input_byte_cnt + group_size -1) / group_size)
+append_byte_cnt = group_cnt * group_size - input_byte_cnt
+output_byte_cnt = input_byte_cnt + append_byte_cnt
+
+print("Input size  = " + str(input_byte_cnt))
+print("Group size  = " + str(group_size))
+print("Append size = " + str(append_byte_cnt))
+print("Output size = " + str(output_byte_cnt))
+
+for i in range(append_byte_cnt):
+	byte_list.append(0)
+i = 0
+while (i < output_byte_cnt):
+	for j in range(int(group_size / 2)):
+		tmp = byte_list[i + j]
+		byte_list[i + j] = byte_list[i + group_size -1 - j]
+		byte_list[i + group_size -1 - j] = tmp
+	i += group_size
+
+output_fd.write(bytearray(byte_list))
+output_fd.close()
+
+print("Done")


### PR DESCRIPTION
… size

- Usage: swap-bytes.py input-file [group-size]
- Append zero-bytes if necessary to input data to keep align with
  group size

Running example
---------------
$ xxd input-example
00000000: 3132 3334 3536 3738 0a61 6263 6465 6667  12345678.abcdefg
00000010: 6869 6a6b 0a21 4023 2425 5e26 2a28 290a  hijk.!@#$%^&*().
00000020: 454e 440a                                END.
$ python3 ./scripts/swap-bytes.py input-example 8
Input size  = 36
Group size  = 8
Append size = 4
Output size = 40
Done
$ xxd input-example-swap8bytes
00000000: 3837 3635 3433 3231 6766 6564 6362 610a  87654321gfedcba.
00000010: 2340 210a 6b6a 6968 0a29 282a 265e 2524  #@!.kjih.)(*&^%$
00000020: 0000 0000 0a44 4e45                      .....DNE

Signed-off-by: Ian Jiang <ianjiang.ict@gmail.com>