### PR TITLE
duowen: Fix command flash gpt

### DIFF
--- a/include/target/efi.h
+++ b/include/target/efi.h
@@ -48,6 +48,7 @@
 #define GPT_LBA_SIZE		512
 #define GPT_HEADER_LBA		1
 #define GPT_HEADER_BYTES	92
+#define GPT_PART_NAME_U16_LEN	36
 
 typedef struct {
 	uint64_t signature;
@@ -81,7 +82,7 @@ typedef struct {
 	uint64_t first_lba;
 	uint64_t last_lba;
 	uint64_t attributes;
-	uint16_t name[36];  /* UTF-16 */
+	uint16_t name[GPT_PART_NAME_U16_LEN];  /* UTF-16 */
 } __packed gpt_partition_entry;
 
 #endif /* __EFI_TARGET_H_INCLUDE__ */


### PR DESCRIPTION
1) Fix bug in converting LBA to byte offset.
2) Change output format to
    part-number start-lba end-lba part-uuid part-name (if any)
For Example:
    1 2048 2127 part-uuid fsbl.bin
    2 4096 32779 part-uuid bbl.bin
    3 34816 65502 part-uuid

Signed-off-by: Ian Jiang <ianjiang.ict@gmail.com>