### PR TITLE
sd: Fix SD read/write API defination and usage

### DIFF
--- a/include/target/mmc.h
+++ b/include/target/mmc.h
@@ -797,13 +797,13 @@ mmc_card_t mmc_register_card(mmc_rca_t rca);
 
 /* MMC external card APIs */
 int mmc_card_read_async(mmc_card_t cid, uint8_t *buf,
-			mmc_lba_t lba, size_t cnt);
+			mmc_lba_t lba, mmc_lba_t cnt);
 int mmc_card_write_async(mmc_card_t cid, uint8_t *buf,
-			 mmc_lba_t lba, size_t cnt);
+			 mmc_lba_t lba, mmc_lba_t cnt);
 int mmc_card_read_sync(mmc_card_t cid, uint8_t *buf,
-		       mmc_lba_t lba, size_t cnt);
+		       mmc_lba_t lba, mmc_lba_t cnt);
 int mmc_card_write_sync(mmc_card_t cid, uint8_t *buf,
-			mmc_lba_t lba, size_t cnt);
+			mmc_lba_t lba, mmc_lba_t cnt);
 mmc_slot_t mmc_card_slot(mmc_card_t cid);
 bool mmc_card_busy(mmc_card_t cid);
 bool mmc_card_capacity(mmc_card_t cid, uint16_t *blk_len, uint64_t *blk_cnt);

--- a/kernel/mmc/card.c
+++ b/kernel/mmc/card.c
@@ -163,7 +163,7 @@ err_exit:
 }
 
 int mmc_card_read_async(mmc_card_t cid, uint8_t *buf,
-			mmc_lba_t lba, size_t cnt)
+			mmc_lba_t lba, mmc_lba_t cnt)
 {
 	__unused mmc_slot_t sslot;
 
@@ -185,7 +185,7 @@ int mmc_card_read_async(mmc_card_t cid, uint8_t *buf,
 }
 
 int mmc_card_write_async(mmc_card_t cid, uint8_t *buf,
-			 mmc_lba_t lba, size_t cnt)
+			 mmc_lba_t lba, mmc_lba_t cnt)
 {
 	__unused mmc_slot_t sslot;
 
@@ -218,7 +218,7 @@ bool mmc_card_busy(mmc_card_t cid)
 }
 
 int mmc_card_read_sync(mmc_card_t cid, uint8_t *buf,
-		       mmc_lba_t lba, size_t cnt)
+		       mmc_lba_t lba, mmc_lba_t cnt)
 {
 	int ret;
 	irq_flags_t flags;
@@ -237,7 +237,7 @@ int mmc_card_read_sync(mmc_card_t cid, uint8_t *buf,
 }
 
 int mmc_card_write_sync(mmc_card_t cid, uint8_t *buf,
-			mmc_lba_t lba, size_t cnt)
+			mmc_lba_t lba, mmc_lba_t cnt)
 {
 	int ret;
 	irq_flags_t flags;

--- a/kernel/mtd/mtd_mmcard.c
+++ b/kernel/mtd/mtd_mmcard.c
@@ -87,7 +87,7 @@ static bool mmcard_buffered(mtd_addr_t addr)
 
 	result = mmc_card_read_sync(mmcard_cid,
 				    mmcard_privs[mmcard_cid].buffer,
-				    blk_off, blk_cnt);
+				    blk_off / MMC_DEF_BL_LEN, blk_cnt);
 	if (result != 0) {
 		con_printf("Failed to read %08lx\n", blk_off);
 		return false;


### PR DESCRIPTION
For mmc_card_read/write_...() functions:
- Use type mmc_lba_t for (block) 'cnt'.
- Make sure that 'lba' stands for LBA number.

Signed-off-by: Ian Jiang <ianjiang.ict@gmail.com>