### PR TITLE
dpu2: EP PCIe device APB and DBI access

### DIFF
--- a/arch/riscv/include/asm/mach-dpu/pci.h
+++ b/arch/riscv/include/asm/mach-dpu/pci.h
@@ -120,15 +120,14 @@
 #define CFG_AXI_CORE_X4_0           0x0
 #define CFG_AXI_CORE_X4_1           0x0
 #else
-#define CFG_APB_PHY_0               0x4500000UL
-#define CFG_APB_SUBSYS              0x4510000UL
-#define CFG_APB_CORE_X16            0x4511000UL
+#define CFG_APB_PHY_0               0x20000800UL
+#define CFG_APB_SUBSYS              0x20000000UL
+#define CFG_APB_CORE_X16            0x20000400UL
 #define CFG_APB_CORE_X8             0x4512000UL
 #define CFG_APB_CORE_X4_0           0x4513000UL
 #define CFG_APB_CORE_X4_1           0x4514000UL
 
-
-#define CFG_AXI_CORE_X16            0x4300000UL
+#define CFG_AXI_CORE_X16            0x20800000UL
 #define CFG_AXI_CORE_X8             0x4380000UL
 #define CFG_AXI_CORE_X4_0           0x4400000UL
 #define CFG_AXI_CORE_X4_1           0x4480000UL
@@ -185,8 +184,12 @@ struct duowen_pcie_subsystem {
 
 #ifdef CONFIG_PCI
 void pci_platform_init(void);
+uint32_t dw_pcie_read_axi(uint64_t addr);
+void dw_pcie_write_axi(uint64_t addr, uint32_t data);
 #else
 #define pci_platform_init()			do { } while (0)
+#define dw_pcie_read_axi(addr) do { } while (0)
+#define dw_pcie_write_axi(addr, data) do { } while (0)
 #endif
 
 #endif /* __PCI_DPU_H_INCLUDE__ */

--- a/arch/riscv/mach-dpu/pcie_dpu.c
+++ b/arch/riscv/mach-dpu/pcie_dpu.c
@@ -8,7 +8,7 @@ struct duowen_pcie_subsystem pcie_subsystem;
 struct dw_pcie controllers[] = {
 	// X16
 	{
-		.axi_dbi_port = AXI_DBI_PORT_X16,
+		//.axi_dbi_port = AXI_DBI_PORT_X16,
 		.dbi_base = CFG_AXI_CORE_X16,
 		.pp.cfg_bar0 = 3*GB + 512*KB,
 		.pp.cfg_bar1 = 3*GB + 1*MB,
@@ -20,7 +20,7 @@ struct dw_pcie controllers[] = {
 #ifndef CONFIG_DPU_GEN2
 	// X8
 	{
-		.axi_dbi_port = AXI_DBI_PORT_X8,
+		//.axi_dbi_port = AXI_DBI_PORT_X8,
 		.dbi_base = CFG_AXI_CORE_X8,
 		.pp.cfg_bar0 = PCIE_CORE_X8_CFG0_START,
 		.pp.cfg_bar1 = PCIE_CORE_X8_CFG1_START,
@@ -31,7 +31,7 @@ struct dw_pcie controllers[] = {
 
 	// X4_0
 	{
-		.axi_dbi_port = AXI_DBI_PORT_X4_0,
+		//.axi_dbi_port = AXI_DBI_PORT_X4_0,
 		.dbi_base = CFG_AXI_CORE_X4_0,
 		.pp.cfg_bar0 = PCIE_CORE_X4_0_CFG0_START,
 		.pp.cfg_bar1 = PCIE_CORE_X4_0_CFG1_START,
@@ -42,7 +42,7 @@ struct dw_pcie controllers[] = {
 
 	//X4_1
 	{
-		.axi_dbi_port = AXI_DBI_PORT_X4_1,
+		//.axi_dbi_port = AXI_DBI_PORT_X4_1,
 		.dbi_base = CFG_AXI_CORE_X4_1,
 		.pp.cfg_bar0 = PCIE_CORE_X4_1_CFG0_START,
 		.pp.cfg_bar1 = PCIE_CORE_X4_1_CFG1_START,
@@ -56,23 +56,47 @@ struct dw_pcie controllers[] = {
 uint32_t read_apb(uint64_t addr, uint8_t port)
 {
 	uint32_t data;
+
 #ifdef IPBENCH
 	apb_read_c(addr, &data, port);
 #else
-	data = readl(addr);
+	data = __raw_readl(addr);
 #endif
-	printf("ReadAPB: addr: 0x%08x; data: 0x%08x, port: %d\n", addr, data, port);
+#ifdef CONFIG_DW_PCIE_DEBUG
+	con_dbg("ReadAPB: addr: 0x%x; data: 0x%x, port: %d\n", addr, data, port);
+#endif
 	return data;
 }
 
 void write_apb(uint64_t addr, uint32_t data, uint8_t port)
 {
-	printf("WriteAPB: addr: 0x%llx; data: 0x%x port: %d\n", addr, data, port);
+#ifdef CONFIG_DW_PCIE_DEBUG
+	con_dbg("WriteAPB: addr: 0x%x; data: 0x%x port: %d\n", addr, data, port);
+#endif
 #ifdef IPBENCH
 	apb_write_c(addr, data, port);
 #else
-	writel(addr, data);
+	__raw_writel(data, addr);
 #endif
+}
+
+uint32_t dw_pcie_read_axi(uint64_t addr)
+{
+	uint32_t data;
+
+	data = __raw_readl(addr);
+#ifdef CONFIG_DUOWEN_PCIE_DEBUG
+	con_dbg("dw_pcie: AXI(R): 0x%llx=0x%x\n", addr, data);
+#endif
+	return data;
+}
+
+void dw_pcie_write_axi(uint64_t addr, uint32_t data)
+{
+#ifdef CONFIG_DUOWEN_PCIE_DEBUG
+	con_dbg("dw_pcie: AXI(W): 0x%llx=0x%x\n", addr, data);
+#endif
+	__raw_writel(data, addr);
 }
 
 


### PR DESCRIPTION
This patch adds the APB and DBI access ways for configuring
the PCIe controller.

Signed-off-by: kaiming xiao <xiaokaiming@smart-core.cn>