### PR TITLE
dpu2: PCIe DMA and ATU funciton verification.

### DIFF
--- a/arch/riscv/include/asm/mach-dpu/pci.h
+++ b/arch/riscv/include/asm/mach-dpu/pci.h
@@ -160,6 +160,88 @@
 #define INTA_INT    1
 #endif
 
+#define PCIE_RC_ADDR_LOW_REG 0x824
+#define PCIE_RC_ADDR_HI_REG 0x828
+#define PCIE_EP_ADDR_LOW_REG 0x82c
+#define PCIE_EP_ADDR_HI_REG 0x834
+#define PCIE_HUGE_DATA_SIZE_REG 0x838
+#define PCIE_RC_RCVED_REG 0x840
+#define PCIE_EP_RCVED_REG 0x844
+#define PCIE_EP_WR_SIZE_PERTIME_REG 0x84c
+
+#define PCIE_DDR_BASE_ADDR_LOW_REG 0x820
+#define PCIE_DDR_BASE_ADDR_HI_REG 0x850
+
+#define PCIE_CMD_REG 0x858
+/*
+ * reg[2:0]:
+ * 1: mem alloc
+ * 2: mem free
+ * 3: mem dump
+ * 7: invalid cmd
+ */
+#define MEM_ALLOC_REQ 1
+#define MEM_FREE_REQ 2
+#define MEM_DUMP_REQ 3
+#define INVALID_CMD_REQ 7
+
+#define PCIE_TOTAL_SIZE_LW_REG 0x85c
+/*
+ * reg[31:0]:total_size[31:0]
+ */
+
+#define PCIE_TOTAL_SIZE_HI_REG 0x864
+/*
+ * reg[3:0]:total_size[35:32]
+ */
+
+#define PCIE_FLAG_REG 0x868
+/*
+ * reg[2:0]
+ * for rc2ep:
+ *      0: last package finished
+ *      1: malloc requrest
+ *      4: run mcu_code
+ * for ep2rc:
+ *      2:ep return malloc response
+ *      3:ep last package finished
+ *      5:ep return free response
+ *      6:ep run mcu code ok response
+ */
+#define EP2RC_INVALID_FLG 0
+#define RC2EP_LAST_PKG_FLG 1
+#define RC2EP_MEM_ALLOC_REQ_FLG 2
+#define EP2RC_MALLOC_OK_FLG 3
+#define EP2RC_LAST_PKG_FLG 4
+#define RC2EP_RUN_MCU_CODE_FLG 5
+#define EP2RC_FREE_OK_FLG 6
+#define EP2RC_RUN_MCU_OK_FLG 7
+
+#define EP_ALLOCED_MEM_LW_REG 0x870
+/*
+ * reg[31:0]: addr[31:0]
+ */
+
+#define EP_ALLOCED_MEM_HI_REG 0x874
+/*
+ * reg[3:0]: addr[35:32]
+ */
+#define RC_FREE_MEM_LW_REG 0x87c
+/*
+ * reg[31:0]: addr[31:0]
+ */
+
+#define RC_FREE_MEM_HI_REG 0x880
+/*
+ * reg[3:0]: addr[35:32]
+ * reg[7:4]: reserved page for invalid DMA
+ */
+
+#define EP_RSVED_MEM_LW_REG 0x888
+/*
+ * reg[31:0]: addr[31:0]
+ */
+
 #ifdef IPBENCH
 void apb_read_c(uint32_t addr, uint32_t *data, int port);
 void apb_write_c(uint32_t addr, uint32_t data, int port);

--- a/arch/riscv/mach-dpu/Kconfig
+++ b/arch/riscv/mach-dpu/Kconfig
@@ -506,6 +506,17 @@ config DPU_PCIE_TEST
 	  or RC will be implemented, depends on whether PCIE_ROLE_RC
 	  is checked
 
+if DPU_PCIE_TEST
+
+config DPU_INITIATE_DMA_BY_LOCAL
+	bool "Initiate DMA by local when in zebu test"
+	default n
+	help
+	  When this option is enabled, RC alloc and tell EP the allocced addr
+	  for DMA through ATU configuration, so that EP can get the RC allocced
+	  addr by reading local DDR memroy.
+
+endif
 endif
 
 endmenu

--- a/drivers/pci/pcie_designware.c
+++ b/drivers/pci/pcie_designware.c
@@ -607,7 +607,7 @@ void dw_pcie_setup_dpu2(struct pcie_port *pp)
 #ifdef CONFIG_DW_PCIE_SPEED_GEN1
 	printf("gen1 speed cfg\n");
 	/* link_control2_link_status */
-	val = dw_pcie_read_dbi(pci, DW_PCIE_CDM, 0xa0, 0x4); 
+	val = dw_pcie_read_dbi(pci, DW_PCIE_CDM, 0xa0, 0x4);
 	val &= 0xfffffff0;
 	val |= 0x1;
 	dw_pcie_write_dbi(pci, DW_PCIE_CDM, 0xa0, val, 0x4);


### PR DESCRIPTION
This patch adds the PCIe DMA and ATU funciton verification
under vcs and zebu.
1.DMA from/to EP memory to/from RC VIP memory in vcs,
  To configure RC memory by ATU at EP side.
2.DMA from/to EP memory to/from RC memory in zebu,
  To configure RC memory with info like RC addr allocced,
  functionID (ATU rd/write,DMA) at RC side, and
  EP can read this info by ATU and then do the
  corresponding functionID test.

Signed-off-by: kaiming xiao <xiaokaiming@smart-core.cn>