### PR TITLE
dpu2: Supports running PE CASE through PCIe.

### DIFF
--- a/arch/riscv/include/asm/mach-dpu/pci.h
+++ b/arch/riscv/include/asm/mach-dpu/pci.h
@@ -268,10 +268,14 @@ struct duowen_pcie_subsystem {
 void pci_platform_init(void);
 uint32_t dw_pcie_read_axi(uint64_t addr);
 void dw_pcie_write_axi(uint64_t addr, uint32_t data);
+void pcie_dw_dma_ep2rc(uint8_t channel, uint64_t src, uint32_t size);
+uint64_t rd_pcie_rsved_reg_4_baseaddr(uint32_t addr_low, uint32_t addr_hi);
 #else
 #define pci_platform_init()			do { } while (0)
 #define dw_pcie_read_axi(addr) do { } while (0)
 #define dw_pcie_write_axi(addr, data) do { } while (0)
+#define pcie_dw_dma_ep2rc(channel, src, size) do { } while (0)
+#define rd_pcie_rsved_reg_4_baseaddr(addr_low, addr_hi) do { } while (0)
 #endif
 
 #endif /* __PCI_DPU_H_INCLUDE__ */

--- a/kernel/page.c
+++ b/kernel/page.c
@@ -163,7 +163,7 @@ static int do_page_alloc(int argc, char **argv)
 	return 0;
 }
 
-static int do_page_dump(int argc, char **argv)
+int do_page_dump(int argc, char **argv)
 {
 	struct page *page;
 


### PR DESCRIPTION
This patch mainly supports PE CASE running through PCIe:
1.EP reserve 4K memory for invalid DMA operation.
2.Invalid DMA means the dest addr equals to EP reserved addr.
3.when invalid DMA comes, RC will tell EP to do:
  1)memory alloc
  2)memory free
  3)memory dump
4.Valid DMA means huge data comes from RC.
  EP just tell RC the huge data received,
  and then RC can send next huge data.
5.Forever poll to see whether need to run PE CASE code.
  RC tells EP to run PE CASE code, and EP side cpu jump
  to excute the code and return ready for next PE CASE
  code running.
6.Support two APIs for PE CASE:
  One for PCIe DMA results to RC,
  Another for getting the DDR addr dynamicly for PE CASE.

Signed-off-by: kaiming xiao <xiaokaiming@smart-core.cn>